### PR TITLE
Update class-bjgk-genesis-enews-extended.php

### DIFF
--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -1,5 +1,16 @@
 <?php
 /**
+ * Genesis eNews Extended
+ *
+ * @package   BJGK\Genesis_enews_extended
+ * @version   1.0.0
+ * @author    Brandon Kraft <public@brandonkraft.com>
+ * @link      http://www.brandonkraft.com/
+ * @copyright Copyright (c) 2012, Brandon Kraft
+ * @license   GPL-2.0+
+ */
+ 
+/**
  * Main plugin class.
  *
  * @package BJGK\Genesis_enews_extended


### PR DESCRIPTION
Add file-level DocBlock.

Not changed in this commit, but the `@link` should point somewhere more specific for this plugin - either the .org repo, this GitHub repo, or a page on BK.com specifically for the plugin (if it exists).
