### PR TITLE
Add an "onClick" field to submit button

### DIFF
--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -46,6 +46,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			'id'               => '',
 			'email-field'      => '',
 			'action'           => '',
+                        'onclick_text'          => '',
 		);
 
 		$widget_ops = array(
@@ -109,7 +110,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<label for="subbox" class="screenread"><?php echo esc_attr( $instance['input_text'] ); ?></label><input type="<?php echo current_theme_supports( 'html5' ) ? 'email' : 'text'; ?>" value="<?php echo esc_attr( $instance['input_text'] ); ?>" id="subbox" onfocus="if ( this.value == '<?php echo esc_js( $instance['input_text'] ); ?>') { this.value = ''; }" onblur="if ( this.value == '' ) { this.value = '<?php echo esc_js( $instance['input_text'] ); ?>'; }" name="email" <?php if ( current_theme_supports( 'html5' ) ) : ?>required="required"<?php endif; ?> />
 			<input type="hidden" name="uri" value="<?php echo esc_attr( $instance['id'] ); ?>" />
 			<input type="hidden" name="loc" value="<?php echo esc_attr( get_locale() ); ?>" />
-			<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" />
+                              <input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" <?php if ( ! empty( $instance['onclick_text'] ) ) : ?>onClick="<?php echo esc_attr( $instance['onclick_text'] ); ?>"<?php endif; ?>/>
 		</form>
 		<?php elseif ( ! empty( $instance['action'] ) ) : ?>
 		<form id="subscribe" action="<?php echo esc_attr( $instance['action'] ); ?>" method="post" <?php if ($instance['open_same_window'] == 0 ) : ?> target="_blank"<?php endif; ?> onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
@@ -117,7 +118,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<?php if ( ! empty($instance['lname-field'] ) ) : ?><label for="subbox2" class="screenread"><?php echo esc_attr( $instance['lname_text'] ); ?></label><input type="text" id="subbox2" class="enews-subbox" value="<?php echo esc_attr( $instance['lname_text'] ); ?>" onfocus="if ( this.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { this.value = ''; }" onblur="if ( this.value == '' ) { this.value = '<?php echo esc_js( $instance['lname_text'] ); ?>'; }" name="<?php echo esc_attr( $instance['lname-field'] ); ?>" /><?php endif ?>
 			<label for="subbox" class="screenread"><?php echo esc_attr( $instance['input_text'] ); ?></label><input type="<?php echo current_theme_supports( 'html5' ) ? 'email' : 'text'; ?>" value="<?php echo esc_attr( $instance['input_text'] ); ?>" id="subbox" onfocus="if ( this.value == '<?php echo esc_js( $instance['input_text'] ); ?>') { this.value = ''; }" onblur="if ( this.value == '' ) { this.value = '<?php echo esc_js( $instance['input_text'] ); ?>'; }" name="<?php echo esc_js( $instance['email-field'] ); ?>" <?php if ( current_theme_supports( 'html5' ) ) : ?>required="required"<?php endif; ?> />
 			<?php echo $instance['hidden_fields']; ?>
-			<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" />
+			<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" <?php if ( ! empty( $instance['onclick_text'] ) ) : ?>onClick="<?php echo esc_attr( $instance['onclick_text'] ); ?>"<?php endif; ?>/>
 		</form>
 		<?php elseif ( ! empty( $instance['mailpoet-list'] ) && 'disabled' != $instance['mailpoet-list'] ) : ?>
 		<form id="subscribe" action="<?php echo $current_url; ?>" method="post" onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
@@ -135,7 +136,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<label for="subbox" class="screenread"><?php echo esc_attr( $instance['input_text'] ); ?></label><input type="<?php echo current_theme_supports( 'html5' ) ? 'email' : 'text'; ?>" value="<?php echo esc_attr( $instance['input_text'] ); ?>" id="subbox" onfocus="if ( this.value == '<?php echo esc_js( $instance['input_text'] ); ?>') { this.value = ''; }" onblur="if ( this.value == '' ) { this.value = '<?php echo esc_js( $instance['input_text'] ); ?>'; }" name="mailpoet-email" <?php if ( current_theme_supports( 'html5' ) ) : ?>required="required"<?php endif; ?> />
 			<?php echo $instance['hidden_fields']; ?>
 			<input type="hidden" name="submission-type" value="mailpoet" />
-			<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" />
+			<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" <?php if ( ! empty( $instance['onclick_text'] ) ) : ?>onClick="<?php echo esc_attr( $instance['onclick_text'] ); ?>"<?php endif; ?>/>
 		</form>
 		<?php endif;
 		echo wpautop( $instance['after_text'] ); // We run KSES on update
@@ -285,7 +286,13 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<?php $input_text = empty( $instance['input_text'] ) ? __( 'E-Mail Address', 'genesis-enews-extended' ) : $instance['input_text']; ?>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>"><?php _e( 'E-Mail Input Text', 'genesis-enews-extended' ); ?>:</label>
 			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'input_text' ) ); ?>" value="<?php echo esc_attr( $input_text ); ?>" class="widefat" />
-		</p>
+                                                                                                                                                                         </p>
+
+		<p>
+			<?php $button_text = empty( $instance['onclick_text'] ) ? __( 'Go', 'genesis-enews-extended' ) : $instance['onclick_text']; ?>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>"><?php _e( 'OnClick Text', 'genesis-enews-extended' ); ?>:</label>
+			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'onclick_text' ) ); ?>" value="<?php echo esc_attr( $onclick_text ); ?>" class="widefat" />
+		</p>                                                                                                                                                                         
 
 		<p>
 			<?php $button_text = empty( $instance['button_text'] ) ? __( 'Go', 'genesis-enews-extended' ) : $instance['button_text']; ?>

--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -46,7 +46,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			'id'               => '',
 			'email-field'      => '',
 			'action'           => '',
-                        'onclick_text'          => '',
+                        'onclick_text'     => '',
 		);
 
 		$widget_ops = array(
@@ -110,7 +110,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<label for="subbox" class="screenread"><?php echo esc_attr( $instance['input_text'] ); ?></label><input type="<?php echo current_theme_supports( 'html5' ) ? 'email' : 'text'; ?>" value="<?php echo esc_attr( $instance['input_text'] ); ?>" id="subbox" onfocus="if ( this.value == '<?php echo esc_js( $instance['input_text'] ); ?>') { this.value = ''; }" onblur="if ( this.value == '' ) { this.value = '<?php echo esc_js( $instance['input_text'] ); ?>'; }" name="email" <?php if ( current_theme_supports( 'html5' ) ) : ?>required="required"<?php endif; ?> />
 			<input type="hidden" name="uri" value="<?php echo esc_attr( $instance['id'] ); ?>" />
 			<input type="hidden" name="loc" value="<?php echo esc_attr( get_locale() ); ?>" />
-                              <input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" <?php if ( ! empty( $instance['onclick_text'] ) ) : ?>onClick="<?php echo esc_attr( $instance['onclick_text'] ); ?>"<?php endif; ?>/>
+                        <input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" <?php if ( ! empty( $instance['onclick_text'] ) ) : ?>onClick="<?php echo esc_attr( $instance['onclick_text'] ); ?>"<?php endif; ?>/>
 		</form>
 		<?php elseif ( ! empty( $instance['action'] ) ) : ?>
 		<form id="subscribe" action="<?php echo esc_attr( $instance['action'] ); ?>" method="post" <?php if ($instance['open_same_window'] == 0 ) : ?> target="_blank"<?php endif; ?> onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
@@ -265,7 +265,8 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<label for="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>"><?php _e( 'onClick', 'genesis-enews-extended' ); ?>:</label>
 			<textarea id="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'onclick_text' ) ); ?>" class="widefat"><?php echo esc_attr( $instance['onclick_text'] ); ?></textarea>
                                                                                                                                                                                                                                                                <br><small><?php _e( 'If you\'re using Google Analytics\'s event tracking to track button presses, that code goes here.', 'genesis-enews-extended'); ?></small>
-                                                                                                                        </p>
+                </p>
+                                                                                                                                                                                                                                                                                                                                                                                                                             
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'hidden_fields' ) ); ?>"><?php _e( 'Hidden Fields', 'genesis-enews-extended' ); ?>:</label>
 			<textarea id="<?php echo esc_attr( $this->get_field_id( 'hidden_fields' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'hidden_fields' ) ); ?>" class="widefat"><?php echo esc_attr( $instance['hidden_fields'] ); ?></textarea>
@@ -290,7 +291,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<?php $input_text = empty( $instance['input_text'] ) ? __( 'E-Mail Address', 'genesis-enews-extended' ) : $instance['input_text']; ?>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>"><?php _e( 'E-Mail Input Text', 'genesis-enews-extended' ); ?>:</label>
 			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'input_text' ) ); ?>" value="<?php echo esc_attr( $input_text ); ?>" class="widefat" />
-                                                                                                                                                                         </p>                                                                                                                                                                         
+                </p>                                                                                                                                                                         
 
 		<p>
 			<?php $button_text = empty( $instance['button_text'] ) ? __( 'Go', 'genesis-enews-extended' ) : $instance['button_text']; ?>

--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -264,7 +264,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>"><?php _e( 'onClick', 'genesis-enews-extended' ); ?>:</label>
 			<textarea id="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'onclick_text' ) ); ?>" class="widefat"><?php echo esc_attr( $instance['onclick_text'] ); ?></textarea>
-                                                                                                                                                                                                                                                               <br><small><?php _e( 'If using Google Analytics\'s event tracking, that goes here.', 'genesis-enews-extended'); ?></small>
+                                                                                                                                                                                                                                                               <br><small><?php _e( 'If you\'re using Google Analytics\'s event tracking to track button presses, that code goes here.', 'genesis-enews-extended'); ?></small>
                                                                                                                         </p>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'hidden_fields' ) ); ?>"><?php _e( 'Hidden Fields', 'genesis-enews-extended' ); ?>:</label>

--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -262,11 +262,15 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 		</p>
 
 		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>"><?php _e( 'onClick', 'genesis-enews-extended' ); ?>:</label>
+			<textarea id="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'onclick_text' ) ); ?>" class="widefat"><?php echo esc_attr( $instance['onclick_text'] ); ?></textarea>
+                                                                                                                                                                                                                                                               <br><small><?php _e( 'If using Google Analytics\'s event tracking, that goes here.', 'genesis-enews-extended'); ?></small>
+                                                                                                                        </p>
+		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'hidden_fields' ) ); ?>"><?php _e( 'Hidden Fields', 'genesis-enews-extended' ); ?>:</label>
 			<textarea id="<?php echo esc_attr( $this->get_field_id( 'hidden_fields' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'hidden_fields' ) ); ?>" class="widefat"><?php echo esc_attr( $instance['hidden_fields'] ); ?></textarea>
 			<br><small><?php _e( 'Not all services use hidden fields.', 'genesis-enews-extended'); ?></small>
-		</p>
-
+                                                                                                                        </p>
 		<p>
 			<input id="<?php echo esc_attr( $this->get_field_id( 'open_same_window' ) ); ?>" type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'open_same_window' ) ); ?>" value="1" <?php checked( $instance['open_same_window'] ); ?>/>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'open_same_window' ) ); ?>"><?php _e( 'Open confirmation page in same window?', 'genesis-enews-extended' ); ?></label>
@@ -286,13 +290,7 @@ class BJGK_Genesis_eNews_Extended extends WP_Widget {
 			<?php $input_text = empty( $instance['input_text'] ) ? __( 'E-Mail Address', 'genesis-enews-extended' ) : $instance['input_text']; ?>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>"><?php _e( 'E-Mail Input Text', 'genesis-enews-extended' ); ?>:</label>
 			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'input_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'input_text' ) ); ?>" value="<?php echo esc_attr( $input_text ); ?>" class="widefat" />
-                                                                                                                                                                         </p>
-
-		<p>
-			<?php $button_text = empty( $instance['onclick_text'] ) ? __( 'Go', 'genesis-enews-extended' ) : $instance['onclick_text']; ?>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>"><?php _e( 'OnClick Text', 'genesis-enews-extended' ); ?>:</label>
-			<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'onclick_text' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'onclick_text' ) ); ?>" value="<?php echo esc_attr( $onclick_text ); ?>" class="widefat" />
-		</p>                                                                                                                                                                         
+                                                                                                                                                                         </p>                                                                                                                                                                         
 
 		<p>
 			<?php $button_text = empty( $instance['button_text'] ) ? __( 'Go', 'genesis-enews-extended' ) : $instance['button_text']; ?>


### PR DESCRIPTION
Hey, Brandon,

Love the plugin. I use it across a couple of different Wordpress installs -- great stuff, thanks!

I wanted to track clicks on different mailing list signup forms across the site, to see what is working and what isn't. The easiest way to do this was to use Google Events tracking via an onClick parameter. So I hacked together a version of the plugin that supports that.

Concretely:
![screen shot 2014-09-12 at 11 35 42 pm](https://cloud.githubusercontent.com/assets/221121/4259588/7d241b28-3aff-11e4-8971-c7e61beb9832.png)

And this changes the generated HTML to this:

```
 <input value="Join Us" id="subbutton" onclick="ga('send', 'event', 'Button', 'OptIn', 'Sidebar - Top');" type="submit">
```

Not sure if this is something you're looking to add support for, but I figured I'd submit the pull request anyways. Oh, and my PHP skills are completely limited to what I've learned breaking WordPress, so, uh, buyer beware. 
