### PR TITLE
Add AMP-compatibility

### DIFF
--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -128,7 +128,18 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 		echo wpautop( apply_filters( 'gee_text', $instance['text'] ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $instance['id'] ) ) : ?>
-			<form id="subscribe-<?php echo esc_attr( $this->id ); ?>" action="https://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open( 'http://feedburner.google.com/fb/a/mailverify?uri=<?php echo esc_js( $instance['id'] ); ?>', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true" name="<?php echo esc_attr( $this->id ); ?>">
+			<form
+				id="subscribe-<?php echo esc_attr( $this->id ); ?>"
+				action="https://feedburner.google.com/fb/a/mailverify"
+				method="post"
+				name="<?php echo esc_attr( $this->id ); ?>"
+				<?php if ( ! $this->is_amp() ) : ?>
+					target="popupwindow"
+					onsubmit="window.open( 'https://feedburner.google.com/fb/a/mailverify?uri=<?php echo esc_js( $instance['id'] ); ?>', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true"
+				<?php else: ?>
+					on="<?php echo esc_attr( sprintf( "submit-success:AMP.navigateTo( url=%s, target=_blank )", wp_json_encode( 'https://feedburner.google.com/fb/a/mailverify?uri=' . $instance['id'], JSON_UNESCAPED_SLASHES ) ) ); ?>"
+				<?php endif; ?>
+			>
 				<label for="subbox" class="screenread"><?php echo esc_attr( $instance['input_text'] ); ?></label><input type="<?php echo current_theme_supports( 'html5' ) ? 'email' : 'text'; ?>" value="" id="subbox" placeholder="<?php echo esc_attr( $instance['input_text'] ); ?>" name="email"
 																	<?php
 																	if ( current_theme_supports( 'html5' ) ) :
@@ -137,6 +148,10 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 				<input type="hidden" name="uri" value="<?php echo esc_attr( $instance['id'] ); ?>" />
 				<input type="hidden" name="loc" value="<?php echo esc_attr( get_locale() ); ?>" />
 				<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" />
+
+				<?php if ( $this->is_amp() ) : ?>
+					<div submit-success><!-- Suppress the success message from the AMP plugin because the result is shown in the opened window. --></div>
+				<?php endif; ?>
 			</form>
 		<?php elseif ( ! empty( $instance['action'] ) ) : ?>
 			<form id="subscribe<?php echo esc_attr( $this->id ); ?>" action="<?php echo esc_attr( $instance['action'] ); ?>" method="post"

--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -147,7 +147,8 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 					echo ' target="_blank" ';
 				}
 				?>
-				onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
+				name="<?php echo esc_attr( $this->id ); ?>"
+			>
 				<?php
 				if ( ! empty( $instance['fname-field'] ) ) :
 ?>
@@ -165,7 +166,7 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 				<input type="submit" value="<?php echo esc_attr( $instance['button_text'] ); ?>" id="subbutton" />
 			</form>
 		<?php elseif ( ! empty( $instance['mailpoet-list'] ) && 'disabled' !== $instance['mailpoet-list'] ) : ?>
-			<form id="subscribe<?php echo esc_attr( $this->id ); ?>" action="<?php echo esc_attr( $current_url ); ?>" method="post" onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
+			<form id="subscribe<?php echo esc_attr( $this->id ); ?>" action="<?php echo esc_attr( $current_url ); ?>" method="post" name="<?php echo esc_attr( $this->id ); ?>">
 				<?php
 				if ( ! empty( $mailpoet_subscriber_id ) && is_int( $mailpoet_subscriber_id ) ) :
 					// confirmation message phrasing depends on whether the user has to verify his subscription or not.

--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -60,6 +60,15 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 	}
 
 	/**
+	 * Returns whether it is an AMP page.
+	 *
+	 * @return bool
+	 */
+	protected function is_amp() {
+		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	}
+
+	/**
 	 * Echo the widget content.
 	 *
 	 * The WordPress.CSRF.NonceVerification sniff is disabled since we are dealing with intentionally logged-out submissions.
@@ -131,10 +140,14 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 			</form>
 		<?php elseif ( ! empty( $instance['action'] ) ) : ?>
 			<form id="subscribe<?php echo esc_attr( $this->id ); ?>" action="<?php echo esc_attr( $instance['action'] ); ?>" method="post"
-											<?php
-											if ( 0 === $instance['open_same_window'] ) :
-								?>
-								target="_blank"<?php endif; ?> onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
+				<?php
+				// The AMP condition is used here because if the form submission handler does a redirect, the amp-form component will error with:
+				// "Redirecting to target=_blank using AMP-Redirect-To is currently not supported, use target=_top instead".
+				if ( 0 === $instance['open_same_window'] && ! $this->is_amp() ) {
+					echo ' target="_blank" ';
+				}
+				?>
+				onsubmit="if ( subbox1.value == '<?php echo esc_js( $instance['fname_text'] ); ?>') { subbox1.value = ''; } if ( subbox2.value == '<?php echo esc_js( $instance['lname_text'] ); ?>') { subbox2.value = ''; }" name="<?php echo esc_attr( $this->id ); ?>">
 				<?php
 				if ( ! empty( $instance['fname-field'] ) ) :
 ?>


### PR DESCRIPTION
This PR depends on https://github.com/ampproject/amp-wp/pull/4212. An `amp.zip` test build is available here: https://github.com/ampproject/amp-wp/pull/4212#issuecomment-582654024

Changes:

* Remove `onsubmit` handler for resetting form fields which appears to be obsolete from a time before `placeholder` was a thing.
* Emulate FeedBurner form submission behavior by opening the results in a new window as opposed to a popup.
* Prevent adding `target=_blank` to the form in AMP since `amp-form` does not allow it when the response attempts to redirect. It shows this error:
<img width="1190" alt="Screen Shot 2020-02-05 at 15 13 06" src="https://user-images.githubusercontent.com/134745/73893565-e1ab0b00-482e-11ea-964b-08b75da38156.png">
