### PR TITLE
Allow shortcodes in widget text areas

### DIFF
--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -134,7 +134,8 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 		}
 
 		// We run KSES on update since we want to allow some HTML, so ignoring the output escape check.
-		echo wpautop( apply_filters( 'gee_text', $instance['text'] ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// gee_text_content runs after wpautop, matching core's widget_text/widget_text_content split, so block-level shortcode output isn't mangled by wpautop.
+		echo apply_filters( 'gee_text_content', wpautop( apply_filters( 'gee_text', $instance['text'] ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $instance['action'] ) ) : ?>
 			<form id="subscribe-<?php echo esc_attr( $this->id ); ?>" class="enews-form" action="<?php echo esc_url( $instance['action'] ); ?>" method="post"
@@ -179,7 +180,8 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 			the_privacy_policy_link( '<small class="enews-privacy">', '</small>' );
 		}
 		// We run KSES on update since we want to allow some HTML, so ignoring the output escape check.
-		echo wpautop( apply_filters( 'gee_after_text', $instance['after_text'] ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		// gee_after_text_content runs after wpautop, matching core's widget_text/widget_text_content split, so block-level shortcode output isn't mangled by wpautop.
+		echo apply_filters( 'gee_after_text_content', wpautop( apply_filters( 'gee_after_text', $instance['after_text'] ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		// If Genesis is the parent theme.
 		if ( function_exists( 'genesis_markup' ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -46,5 +46,10 @@ function bjgk_genesis_enews_load_widgets() {
 }
 
 // Allow shortcodes in widget text areas by default. See #114.
-add_filter( 'gee_text', 'do_shortcode' );
-add_filter( 'gee_after_text', 'do_shortcode' );
+// Hooked on the *_content filters (post-wpautop) to match core's widget_text_content pattern, and guarded so sites that added do_shortcode themselves don't double-register.
+if ( ! has_filter( 'gee_text_content', 'do_shortcode' ) ) {
+	add_filter( 'gee_text_content', 'do_shortcode' );
+}
+if ( ! has_filter( 'gee_after_text_content', 'do_shortcode' ) ) {
+	add_filter( 'gee_after_text_content', 'do_shortcode' );
+}

--- a/plugin.php
+++ b/plugin.php
@@ -44,3 +44,7 @@ add_action( 'widgets_init', 'bjgk_genesis_enews_load_widgets' );
 function bjgk_genesis_enews_load_widgets() {
 	register_widget( 'BJGK_Genesis_ENews_Extended' );
 }
+
+// Allow shortcodes in widget text areas by default. See #114.
+add_filter( 'gee_text', 'do_shortcode' );
+add_filter( 'gee_after_text', 'do_shortcode' );

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,10 @@ Questions can be asked at the [WordPress.org Support Forum](https://wordpress.or
 2. Widget setting screen.
 
 == Changelog ==
+= 2.4.0 =
+* Shortcodes now render by default in the widget's Text and After Text areas. Matches WordPress core's text widget behavior since 4.9.
+* Added new `gee_text_content` and `gee_after_text_content` filters that run after `wpautop`, mirroring core's `widget_text_content` split. Existing `gee_text` / `gee_after_text` hooks continue to receive raw user input. Sites that want to disable default shortcode processing can `remove_filter( 'gee_text_content', 'do_shortcode' )` (and the same for `gee_after_text_content`).
+
 = 2.3.1 =
 * Restored `subbox`, `subbox1`, `subbox2`, and `subbutton` on the form's input elements (as both `id` and class) for backward compatibility with sites that style off them. Note: when more than one widget instance is on the same page, the IDs will not be unique, which is technically invalid HTML but preserves long-standing behavior.
 


### PR DESCRIPTION
## Summary

Makes WordPress shortcodes render by default in the widget's Text and After Text areas, matching core's text-widget behavior since 4.9.

Fixes #114.

## Approach

Follows core's `widget_text` / `widget_text_content` split:

- Existing `gee_text` / `gee_after_text` filters continue to fire on **raw user input** — contract unchanged.
- Two new filters, `gee_text_content` and `gee_after_text_content`, fire on the **post-wpautop** output. `do_shortcode` is hooked to those.
- Registration guarded with `has_filter()` so sites that already wired up `do_shortcode` themselves aren't double-registered.

This ordering matters: running `do_shortcode` after `wpautop` prevents `wpautop` from mangling block-level shortcode output (`<div>`, `<form>`, `<table>`, etc. — same reason core runs wpautop at priority 10 and do_shortcode at priority 11 on `the_content`).

## Files changed

- `class-bjgk-genesis-enews-extended.php` — adds the new `*_content` filter call at lines 137 and 183.
- `plugin.php` — attaches `do_shortcode` to the new hooks with `has_filter` guards.
- `readme.txt` — 2.4.0 changelog entry documenting the new behavior, new filters, and opt-out path.

## Opt out

```php
remove_filter( 'gee_text_content', 'do_shortcode' );
remove_filter( 'gee_after_text_content', 'do_shortcode' );
```

## Test plan

- [ ] Shortcode in Text area renders on the front end (e.g. a theme-provided shortcode or a form plugin's shortcode).
- [ ] Shortcode in After Text area renders.
- [ ] Block-level shortcode output (`<div>`, `<form>`) is not wrapped in stray `<p>` tags.
- [ ] Non-shortcode text renders unchanged (regression check).
- [ ] Title and hidden-fields outputs are unaffected (no shortcode expansion there).
- [ ] `remove_filter( 'gee_text_content', 'do_shortcode' )` in a theme's functions.php disables shortcode processing.
- [ ] A site with a pre-existing `add_filter( 'gee_text_content', 'do_shortcode' )` doesn't double-register.

## Review trail

- Verified pre-commit by an independent code-reviewer agent.
- Adversarial pass flagged a `wpautop`/`do_shortcode` ordering issue and a potential double-registration concern. The second commit on this branch addresses both.
- Findings about "no dedicated opt-out filter" and "capability boundary with delegated widget caps" were judged out of scope: the former is covered by `remove_filter`, the latter is inherent to any shortcode-capable widget (core has the same property).