### PR TITLE
Restore Hidden Fields attributes stripped in 2.3.0

### DIFF
--- a/class-bjgk-genesis-enews-extended.php
+++ b/class-bjgk-genesis-enews-extended.php
@@ -3,7 +3,7 @@
  * Genesis eNews Extended
  *
  * @package   BJGK\Genesis_enews_extended
- * @version   2.3.1
+ * @version   2.4.0
  * @author    Brandon Kraft <public@brandonkraft.com>
  * @link      https://kraft.blog/genesis-enews-extended/
  * @copyright Copyright (c) 2012-2026, Brandon Kraft
@@ -138,7 +138,7 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 		echo apply_filters( 'gee_text_content', wpautop( apply_filters( 'gee_text', $instance['text'] ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $instance['action'] ) ) : ?>
-			<form id="subscribe-<?php echo esc_attr( $this->id ); ?>" class="enews-form" action="<?php echo esc_url( $instance['action'] ); ?>" method="post"
+			<form id="subscribe<?php echo esc_attr( $this->id ); ?>" class="enews-form" action="<?php echo esc_url( $instance['action'] ); ?>" method="post"
 				<?php
 				// The AMP condition is used here because if the form submission handler does a redirect, the amp-form component will error with:
 				// "Redirecting to target=_blank using AMP-Redirect-To is currently not supported, use target=_top instead".
@@ -231,54 +231,145 @@ class BJGK_Genesis_ENews_Extended extends WP_Widget {
 	/**
 	 * Returns allowed HTML tags and attributes for the hidden fields setting.
 	 *
+	 * Permits the attributes vendor newsletter snippets typically rely on
+	 * (placeholder, required, aria-*, data-*, validation/autocomplete hints,
+	 * etc.) while excluding event handlers and form-overriding attributes
+	 * (on*, formaction, formmethod, formtarget, formenctype, formnovalidate)
+	 * that could otherwise redirect submissions or execute JavaScript.
+	 *
 	 * @since 2.3.0
 	 *
 	 * @return array Allowed HTML elements and their attributes.
 	 */
 	protected function get_hidden_fields_allowed_html() {
+		$global = array(
+			'id'                => array(),
+			'class'             => array(),
+			'style'             => array(),
+			'title'             => array(),
+			'role'              => array(),
+			'tabindex'          => array(),
+			'hidden'            => array(),
+			'lang'              => array(),
+			'dir'               => array(),
+			'data-*'            => true,
+			// `aria-*` wildcards are not honored by wp_kses; common aria attributes are enumerated.
+			'aria-atomic'       => array(),
+			'aria-busy'         => array(),
+			'aria-controls'     => array(),
+			'aria-current'      => array(),
+			'aria-describedby'  => array(),
+			'aria-details'      => array(),
+			'aria-disabled'     => array(),
+			'aria-expanded'     => array(),
+			'aria-haspopup'     => array(),
+			'aria-hidden'       => array(),
+			'aria-invalid'      => array(),
+			'aria-label'        => array(),
+			'aria-labelledby'   => array(),
+			'aria-live'         => array(),
+			'aria-placeholder'  => array(),
+			'aria-pressed'      => array(),
+			'aria-readonly'     => array(),
+			'aria-required'     => array(),
+			'aria-valuetext'    => array(),
+		);
+
 		return array(
-			'a'        => array(
-				'href'   => array(),
-				'title'  => array(),
-				'target' => array(),
-				'rel'    => array(),
+			'a'        => array_merge(
+				$global,
+				array(
+					'href'     => array(),
+					'target'   => array(),
+					'rel'      => array(),
+					'download' => array(),
+				)
 			),
-			'div'      => array(
-				'class' => array(),
-				'id'    => array(),
-				'style' => array(),
+			'div'      => $global,
+			'fieldset' => array_merge(
+				$global,
+				array(
+					'name'     => array(),
+					'disabled' => array(),
+					'form'     => array(),
+				)
 			),
-			'fieldset' => array(),
-			'input'    => array(
-				'type'  => array(),
-				'name'  => array(),
-				'value' => array(),
-				'id'    => array(),
-				'class' => array(),
+			'input'    => array_merge(
+				$global,
+				array(
+					'type'           => array(),
+					'name'           => array(),
+					'value'          => array(),
+					'placeholder'    => array(),
+					'required'       => array(),
+					'readonly'       => array(),
+					'disabled'       => array(),
+					'checked'        => array(),
+					'autocomplete'   => array(),
+					'autocapitalize' => array(),
+					'autocorrect'    => array(),
+					'spellcheck'     => array(),
+					'inputmode'      => array(),
+					'pattern'        => array(),
+					'min'            => array(),
+					'max'            => array(),
+					'step'           => array(),
+					'minlength'      => array(),
+					'maxlength'      => array(),
+					'size'           => array(),
+					'list'           => array(),
+					'multiple'       => array(),
+					'form'           => array(),
+				)
 			),
-			'label'    => array(
-				'for'   => array(),
-				'class' => array(),
+			'label'    => array_merge( $global, array( 'for' => array() ) ),
+			'legend'   => $global,
+			'option'   => array_merge(
+				$global,
+				array(
+					'value'    => array(),
+					'selected' => array(),
+					'disabled' => array(),
+					'label'    => array(),
+				)
 			),
-			'legend'   => array(),
-			'option'   => array(
-				'value'    => array(),
-				'selected' => array(),
+			'optgroup' => array_merge(
+				$global,
+				array(
+					'label'    => array(),
+					'disabled' => array(),
+				)
 			),
-			'optgroup' => array(
-				'label' => array(),
+			'select'   => array_merge(
+				$global,
+				array(
+					'name'         => array(),
+					'required'     => array(),
+					'disabled'     => array(),
+					'multiple'     => array(),
+					'size'         => array(),
+					'autocomplete' => array(),
+					'form'         => array(),
+				)
 			),
-			'select'   => array(
-				'name'  => array(),
-				'id'    => array(),
-				'class' => array(),
-			),
-			'textarea' => array(
-				'name'  => array(),
-				'id'    => array(),
-				'class' => array(),
-				'rows'  => array(),
-				'cols'  => array(),
+			'textarea' => array_merge(
+				$global,
+				array(
+					'name'           => array(),
+					'rows'           => array(),
+					'cols'           => array(),
+					'placeholder'    => array(),
+					'required'       => array(),
+					'readonly'       => array(),
+					'disabled'       => array(),
+					'minlength'      => array(),
+					'maxlength'      => array(),
+					'autocomplete'   => array(),
+					'autocapitalize' => array(),
+					'spellcheck'     => array(),
+					'wrap'           => array(),
+					'form'           => array(),
+				)
 			),
 		);
 	}

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Genesis eNews Extended
  *
  * @package   BJGK\Genesis_enews_extended
- * @version   2.3.1
+ * @version   2.4.0
  * @author    Brandon Kraft <public@brandonkraft.com>
  * @link      https://kraft.blog/genesis-enews-extended/
  * @copyright Copyright (c) 2012-2026, Brandon Kraft

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Genesis eNews Extended
  *
  * @package     BJGK\Genesis_enews_extended
- * @version     2.3.1
+ * @version     2.4.0
  * @author      Brandon Kraft <public@brandonkraft.com>
  * @copyright   Copyright (c) 2012-2026, Brandon Kraft
  * @link        https://kraft.blog/genesis-enews-extended/
@@ -13,7 +13,7 @@
  * Plugin Name: Genesis eNews Extended
  * Plugin URI:  https://kraft.blog/genesis-enews-extended/
  * Description: Replaces the Genesis eNews Widget to allow easier use of additional mailing services.
- * Version:     2.3.1
+ * Version:     2.4.0
  * Author:      Brandon Kraft
  * Author URI:  https://kraft.blog/
  * License:     GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -48,6 +48,9 @@ Questions can be asked at the [WordPress.org Support Forum](https://wordpress.or
 = 2.4.0 =
 * Shortcodes now render by default in the widget's Text and After Text areas. Matches WordPress core's text widget behavior since 4.9.
 * Added new `gee_text_content` and `gee_after_text_content` filters that run after `wpautop`, mirroring core's `widget_text_content` split. Existing `gee_text` / `gee_after_text` hooks continue to receive raw user input. Sites that want to disable default shortcode processing can `remove_filter( 'gee_text_content', 'do_shortcode' )` (and the same for `gee_after_text_content`).
+* Fixed: inline `style` attributes are no longer stripped from `<input>` elements in the Hidden Fields box. This restores tracking pixels and visually-hidden honeypot fields used by Flodesk and similar services. Props 17thavenue for the report (issue 164).
+* Widened the Hidden Fields allowlist to permit common form attributes that vendor newsletter snippets rely on (`placeholder`, `required`, `autocomplete`, `pattern`, `min`/`max`/`step`, `aria-*`, `data-*`, `tabindex`, `role`, etc.) while continuing to strip event handlers (`on*`) and form-overriding attributes (`formaction`, `formmethod`).
+* Restored the pre-2.3.0 form `id` format (`subscribe<widget-id>`, no hyphen) after 2.3.0 inadvertently changed it to `subscribe-<widget-id>`.
 
 = 2.3.1 =
 * Restored `subbox`, `subbox1`, `subbox2`, and `subbutton` on the form's input elements (as both `id` and class) for backward compatibility with sites that style off them. Note: when more than one widget instance is on the same page, the IDs will not be unique, which is technically invalid HTML but preserves long-standing behavior.
@@ -207,6 +210,9 @@ If you're not listed and think you should be, please drop me a note. Any omissio
 
 
 == Upgrade Notice ==
+
+= 2.4.0 =
+Shortcodes now render in the widget's Text and After Text areas. Also fixes Hidden Fields losing inline `style` attributes (e.g. Flodesk tracking pixels) and restores common form attributes like `placeholder`, `required`, `aria-*`, and `data-*` that vendor signup snippets rely on.
 
 = 2.3.1 =
 Restores `subbox`, `subbox1`, `subbox2`, and `subbutton` on the form inputs (as both `id` and class) after they were removed in 2.3.0. Existing CSS using either `#subbox1` or `.subbox1` will work again.


### PR DESCRIPTION
## Summary

Fixes issue 164 and the broader regression behind it: the 2.3.0 security PR replaced `strip_tags()` with `wp_kses()` for the Hidden Fields setting and used a deliberately narrow attribute allowlist. `strip_tags(text, '<input>...')` keeps every attribute on the listed tags, so the new `wp_kses` contract silently dropped a wide range of attributes that vendor newsletter snippets rely on (the reported `style` plus `placeholder`, `required`, `aria-*`, `data-*`, etc.).

- Adds `style` to the `<input>` allowlist so Flodesk-style tracking pixels and visually-hidden honeypot fields survive (issue 164).
- Widens `get_hidden_fields_allowed_html()` with a shared global attribute set (id, class, style, title, role, tabindex, lang, dir, hidden, `data-*` wildcard, enumerated `aria-*` attributes) plus per-element form attributes (placeholder, required, autocomplete, pattern, min/max/step, etc.). Event handlers (`on*`) and form-overriding attributes (`formaction`, `formmethod`, `formtarget`, `formenctype`, `formnovalidate`) remain stripped.
- Restores the pre-2.3.0 form `id` format `subscribe<widget-id>` (no hyphen). 2.3.0 inadvertently added the hyphen by inheriting the now-removed FeedBurner form's pattern; restoring the prior format keeps any long-standing user CSS/JS selectors working.
- Bumps `@version` and plugin header `Version` to 2.4.0; readme `Stable tag` stays at 2.3.1 until the actual release.
- Folds the 2.4.0 shortcode entries from PR 163 and these Hidden Fields fixes into a single 2.4.0 changelog and upgrade notice.

## Test plan

- [x] Validated against a real WP install: issue 164's exact example (`<input type="text" name="confirm_email_address" style="display: none; background-image: url(...)">`) survives `wp_kses` with both declarations intact.
- [x] Validated common vendor-snippet patterns survive: Mailchimp honeypot (`tabindex="-1"`, `aria-hidden="true"`, `style`), ConvertKit (`data-*` + `aria-label` + `required` + `autocomplete`), `<select>` with `required disabled multiple data-vendor`, hidden inputs with `min`/`max`/`step`/`pattern`.
- [x] Validated dangerous attributes are still stripped: `onclick`, `onerror`, `formaction`/`formmethod`, `javascript:` href, `<script>` tag.
- [x] `php -l` clean on all touched files.
- [ ] Manual smoke test in a real widget instance to confirm rendered HTML.

Fixes #164