### PR TITLE
Prepare 2.4.0 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.9.6
 Requires PHP: 5.4.0
 Tested up to: 7.0
 Text Domain: genesis-enews-extended
-Stable tag: 2.3.1
+Stable tag: 2.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Prep commit for the 2.4.0 release. Once this lands on `develop`, cut a GitHub Release tagged `2.4.0` and the deploy workflow will push to WordPress.org SVN.

## Changes
- Bumps `readme.txt` `Stable tag` from 2.3.1 to 2.4.0.

The plugin header `Version:`, the `@version` docblocks in `plugin.php` and `class-bjgk-genesis-enews-extended.php`, and the `readme.txt` changelog and Upgrade Notice sections for 2.4.0 already landed on `develop` in earlier PRs — this is the deliberate `Stable tag` flip per AGENTS.md.

## Release contents (2.4.0)
- Shortcodes render by default in the widget's Text and After Text areas; new `gee_text_content` / `gee_after_text_content` filters mirror core's `widget_text_content` split.
- Hidden Fields no longer strip inline `style` attributes, restoring Flodesk-style tracking pixels and similar visually-hidden inputs (issue 164).
- Hidden Fields allowlist widened to permit common form attributes (`placeholder`, `required`, `autocomplete`, `pattern`, `aria-*`, `data-*`, etc.) while still stripping `on*` handlers and form-overriding attributes.
- Restored the pre-2.3.0 form `id` format (`subscribe<widget-id>`).

## Test plan
- [ ] CI green.
- [ ] After merge: cut GitHub Release `2.4.0`; verify deploy workflow runs and `https://wordpress.org/plugins/genesis-enews-extended/` shows 2.4.0.