### PR TITLE
ci: bump actions/checkout to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: WordPress plugin deploy
         id: deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         php: ['8.5']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node.js 20 on its runners. `actions/checkout@v4` runs on Node.js 20 and triggers a deprecation warning. This bumps it to `actions/checkout@v6`, which runs on Node.js 24, in both workflows.

- `.github/workflows/deploy.yml` — WordPress.org SVN deploy on release.
- `.github/workflows/test.yml` — PHPUnit on push/PR.

Timeline per the GitHub changelog:
- Node.js 24 becomes the default on June 2, 2026.
- Node.js 20 is removed from runners on September 16, 2026.

`actions/checkout@v6` is the current latest (v6.0.2 as of 2026-01-09) and explicitly supports Node.js 24.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan

- [ ] PHPUnit workflow runs green on this PR.
- [ ] Deploy workflow runs successfully on the next release tag.